### PR TITLE
Replace randomUniform() with placeholder() 

### DIFF
--- a/zhinst/toolkit/helpers/sequence_commands.py
+++ b/zhinst/toolkit/helpers/sequence_commands.py
@@ -92,8 +92,8 @@ class SequenceCommand(object):
         if length % 16:
             raise ValueError("Buffer Length has to be multiple of 16!")
         return (
-            f"wave w{i + 1}_1 = randomUniform({length});\n"
-            f"wave w{i + 1}_2 = randomUniform({length});\n"
+            f"wave w{i + 1}_1 = placeholder({length});\n"
+            f"wave w{i + 1}_2 = placeholder({length});\n"
         )
 
     @staticmethod

--- a/zhinst/toolkit/helpers/sequences.py
+++ b/zhinst/toolkit/helpers/sequences.py
@@ -121,9 +121,21 @@ class Sequence(object):
             self.trigger_cmd_2 = SequenceCommand.comment_line()
             self.dead_cycles = 0
 
-    def time_to_cycles(self, time, wait_time=True):
-        """Helper method to convert time to FPGA clock cycles."""
-        if wait_time:
+    def time_to_cycles(self, time, wait_simple=False):
+        """Helper method to convert time to clock cycles.
+
+        If the argument `wait_simple` isn't passed in, the sampling
+        rate of the device is used as clock rate by default.
+
+        Parameters
+        ----------
+        wait_simple : bool, optional
+            Option to choose whether to return the number of cycles
+            in terms of sequencer rate instead of sampling rate
+            (default is False)
+        """
+
+        if wait_simple:
             return int(time * self.clock_rate / 8)
         else:
             return int(time * self.clock_rate)

--- a/zhinst/toolkit/helpers/sequences.py
+++ b/zhinst/toolkit/helpers/sequences.py
@@ -170,7 +170,7 @@ class Sequence(object):
 class SimpleSequence(Sequence):
     """Sequence for *simple* playback of waveform arrays.
 
-    Initializes placeholders (`randomUniform(...)`) of the correct length for 
+    Initializes placeholders (`placeholder(...)`) of the correct length for 
     the waveforms in the queue of the AWG Core. The data of the waveform 
     placeholders is then replaced in memory when uploading the waveform using 
     `upload_waveforms()`. The waveforms are played sequentially within the main 


### PR DESCRIPTION
Replaced randomUniform() with placeholder().
It should reduce the initial compilation and uploading time for very long waveforms.