### PR TITLE
Add ´factory_reset´ method

### DIFF
--- a/zhinst/toolkit/control/drivers/base/base.py
+++ b/zhinst/toolkit/control/drivers/base/base.py
@@ -121,6 +121,13 @@ class BaseInstrument:
             self._nodetree = NodeTree(self)
         self._options = self._get("/features/options").split("\n")
         self._init_settings()
+        
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        self._set(f"/system/preset/load", 1)
+        print(
+        f"Factory preset is loaded to device {self.serial.upper()}."
+        )
 
     def _init_settings(self):
         """Initial device settings. 

--- a/zhinst/toolkit/control/drivers/hdawg.py
+++ b/zhinst/toolkit/control/drivers/hdawg.py
@@ -72,6 +72,10 @@ class HDAWG(BaseInstrument):
         super().connect_device(nodetree=nodetree)
         [awg._setup() for awg in self.awgs]
 
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        super().factory_reset()
+        
     def _init_settings(self):
         """Sets initial device settings on startup."""
         settings = [

--- a/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/zhinst/toolkit/control/drivers/uhfqa.py
@@ -160,6 +160,10 @@ class UHFQA(BaseInstrument):
         """
         super().connect_device(nodetree=nodetree)
         self.awg._setup()
+        
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        super().factory_reset()
 
     def crosstalk_matrix(self, matrix=None):
         """Sets or gets the crosstalk matrix of the UHFQA as a 2D array.


### PR DESCRIPTION
´factory_reset´ method is added which loads the factory preset to the device.
The method is added to the BaseInstrument class because this method is common to multiples devices: UHFQA, HDAWG.

HDAWG and UHFQA classes call the ´factory_reset´ method from the parent class BaseInsturment.